### PR TITLE
Add CronWorkflow to argo-vreapi service account

### DIFF
--- a/naavre/templates/serviceaccount-argo-vreapi.yaml
+++ b/naavre/templates/serviceaccount-argo-vreapi.yaml
@@ -39,6 +39,7 @@ rules:
       - workflowartifactgctasks
       - workflowtemplates
       - workflows
+      - cronworkflows
   - verbs:
       - patch
     apiGroups:
@@ -47,6 +48,7 @@ rules:
       - workflowtasksets/status
       - workflowartifactgctasks/status
       - workflows/status
+      - cronworkflows/status
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Add the following permissions to the `argo-vreapi` service account:
- `list`, `watch`, `create`, `get`, `update` and `delete` `cronworkflows`
- `patch` on `cronworkflows/status`

The extra permissions allow the NaaVRE-workflow-service to submit and manage `CronWorkflow`s (feature added by https://github.com/NaaVRE/NaaVRE-workflow-service/pull/14)