### PR TITLE
Add redirect to from base domain to PaaS frontend

### DIFF
--- a/naavre/templates/ingress-redirect.yaml
+++ b/naavre/templates/ingress-redirect.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.global.ingress.redirectDomainToPaasFrontend }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "{{ include "naavre.fullname" . }}-redirect-to-paas"
+  annotations:
+    nginx.ingress.kubernetes.io/app-root: /vreapp
+spec:
+  ingressClassName: nginx
+  rules:
+  {{- range $host := index .Values "naavre-paas-frontend" "ingress" "hosts" }}
+    - host: "{{ $host.host }}"
+      http:
+        paths:
+          - path: /
+            pathType: Exact
+            backend:
+              service:
+                name: "{{ template "naavre-paas-frontend.fullname" (index $.Subcharts "naavre-paas-frontend") }}"
+                port:
+                  number: {{ index $.Values "naavre-paas-frontend" "service" "port" }}
+  {{- end }}
+{{- end }}

--- a/naavre/values.yaml
+++ b/naavre/values.yaml
@@ -26,6 +26,9 @@ naavre-paas-frontend:
   enabled: true
 
 global:
+  ingress:
+    redirectDomainToPaasFrontend: false
+
   secrets:
     keycloak:
       client_id:

--- a/values/templates/global.yaml
+++ b/values/templates/global.yaml
@@ -1,4 +1,7 @@
 global:
+  ingress:
+    redirectDomainToPaasFrontend: {{ .Values.global.ingress.redirectDomainToPaasFrontend }}
+
   secrets:
     keycloak:
       {{- if .Values.global.externalServices.keycloak.useExternal }}

--- a/values/values-deploy-k8s-staging-1.public.yaml
+++ b/values/values-deploy-k8s-staging-1.public.yaml
@@ -7,6 +7,7 @@ global:
       cert-manager.io/cluster-issuer: letsencrypt-prod
     tls:
       enabled: true
+    redirectDomainToPaasFrontend: true
 
   externalServices:
     argoWorkflows:

--- a/values/values-deploy-k8s-test-1.public.yaml
+++ b/values/values-deploy-k8s-test-1.public.yaml
@@ -7,6 +7,7 @@ global:
       cert-manager.io/cluster-issuer: letsencrypt-prod
     tls:
       enabled: true
+    redirectDomainToPaasFrontend: true
 
 jupyterhub:
   vlabs:

--- a/values/values.yaml
+++ b/values/values.yaml
@@ -9,6 +9,7 @@ global:
     commonAnnotations: {}
     tls:
       enabled: false
+    redirectDomainToPaasFrontend: false
 
   secrets:
     k8sSecretCreator:


### PR DESCRIPTION
Add an ingress rule to redirect the base domain (e.g. `example.com`) to the PaaS frontend (`example.com/vreapp`).

The rule is disabled by default, and can be enabled by setting `global.ingress.redirectDomainToPaasFrontend=true` in the root values file. 