### PR TITLE
Fix `subPath` for mount of `naa-vre-user-data` bucket

### DIFF
--- a/values/values-deploy-k8s-staging-1.public.yaml
+++ b/values/values-deploy-k8s-staging-1.public.yaml
@@ -85,7 +85,7 @@ jupyterhub:
       mountPath: /home/jovyan/naa-vre-public
     - name: naa-vre-user-data
       mountPath: /home/jovyan/naa-vre-user-data/
-      subPath: '{username}'
+      subPath: '{unescaped_username}'
   vlabs:
     openlab:
       enabled: true


### PR DESCRIPTION
Replace `username` with `unescaped_username`, to match `jwt:preferred_username` used to determine the user's prefix in the bucket. 