### PR TITLE
Enable profile selection in user-redirect

### DIFF
--- a/values/templates/jupyterhub.yaml
+++ b/values/templates/jupyterhub.yaml
@@ -76,6 +76,23 @@ jupyterhub:
                 return super().get_pvc_manifest()
                 return super().get_pod_manifest()
         c.JupyterHub.spawner_class = CustomKubeSpawner
+      custom_user_redirect.py: |
+        from jupyterhub.utils import url_path_join
+        from tornado.httputil import url_concat
+        from urllib.parse import parse_qsl
+        async def custom_user_redirect_hook(path, request, user, base_url):
+          user_url = url_path_join(user.url, path)
+          profile = ""
+          if request.query:
+            query_dict = dict(parse_qsl(request.query))
+            profile = query_dict.pop("profile", "")
+            user_url = url_concat(user_url, query_dict)
+          url = url_concat(
+            url_path_join(base_url, "spawn", user.escaped_name),
+            {"next": user_url, "profile": profile},
+            )
+          return url
+        c.JupyterHub.user_redirect_hook = custom_user_redirect_hook
 
   ingress:
     enabled: true


### PR DESCRIPTION
Add a [`user_redirect_hook`](https://github.com/jupyterhub/jupyterhub/blob/74b5e2601d3b790a77d1a3568432c015026224df/jupyterhub/app.py#L1741-L1756) to handle `/user-redirect/...` URLs. The hook extracts the `profile` and passes it to Jupyter Hub (instead of the singleuser server).