### PR TITLE
Add default_file_path to virtual labs

### DIFF
--- a/values/virtual-labs/values-biodt-hackathon25.public.yaml
+++ b/values/virtual-labs/values-biodt-hackathon25.public.yaml
@@ -22,3 +22,4 @@ jupyterhub:
         git_public:
           repo: https://github.com/QCDIS/Hackathon25.git
           branch: main
+        default_file_path: Virtual Labs/BioDT Hackathon/Git public/README.ipynb

--- a/values/virtual-labs/values-biotisan-euromarec.public.yaml
+++ b/values/virtual-labs/values-biotisan-euromarec.public.yaml
@@ -25,3 +25,4 @@ jupyterhub:
         git_public:
           repo: https://github.com/QCDIS/Biodiversity_time_series_analyses_from_European_marine_ecosystems.git
           branch: main
+        default_file_path: Virtual Labs/Biodiversity Time Series Analyses/Git public/README.md

--- a/values/virtual-labs/values-pclake.public.yaml
+++ b/values/virtual-labs/values-pclake.public.yaml
@@ -20,3 +20,4 @@ jupyterhub:
         git_public:
           repo: https://github.com/LTER-LIFE/PCLake_NaaVRE_workflow.git
           branch: main
+        default_file_path: Virtual Labs/PCLake/Git public/README.md

--- a/values/virtual-labs/values-ravl.public.yaml
+++ b/values/virtual-labs/values-ravl.public.yaml
@@ -20,3 +20,4 @@ jupyterhub:
         git_public:
           repo: https://github.com/NaaVRE/RAVL-virtual-lab.git
           branch: main
+        default_file_path: Virtual Labs/RAVL/Git public/README.md

--- a/values/virtual-labs/values-reprolab.public.yaml
+++ b/values/virtual-labs/values-reprolab.public.yaml
@@ -20,3 +20,4 @@ jupyterhub:
         git_public:
           repo: https://github.com/NaaVRE/vl-reprolab.git
           branch: main
+        default_file_path: Virtual Labs/Reprolab/Git public/README.md

--- a/values/virtual-labs/values-waddenzee-proto-dt.public.yaml
+++ b/values/virtual-labs/values-waddenzee-proto-dt.public.yaml
@@ -20,3 +20,4 @@ jupyterhub:
         git_public:
           repo: https://github.com/LTER-LIFE/notebooks-workflows-Wadden-protoDT-naavre-.git
           branch: main
+        default_file_path: Virtual Labs/Waddenzee proto DT/Git public/README.md


### PR DESCRIPTION
Add `default_file_path` to virtual labs that pull from a `git_public` and for which the repo contains a README. See list at https://github.com/QCDIS/projects_overview/issues/454#issuecomment-3503216488