### PR TITLE
Hide first time and feedback modals from argo

### DIFF
--- a/values/templates/argo-workflows.yaml
+++ b/values/templates/argo-workflows.yaml
@@ -75,6 +75,13 @@ argo-workflows:
     enabled: true
     baseHref: "/{{ trimAll "/" .Values.argoWorkflows.ingress.basePath }}/"
     serviceType: ClusterIP
+    extraEnv:
+      - name: FIRST_TIME_USER_MODAL
+        value: "false"
+      - name: FEEDBACK_MODAL
+        value: "false"
+      - name: NEW_VERSION_MODAL
+        value: "false"
     sso:
       enabled: true
       {{- if .Values.global.externalServices.keycloak.useExternal }}


### PR DESCRIPTION
Hides the first time, first version and feedback modals from Argo workflows ([documentation](https://argo-workflows.readthedocs.io/en/latest/environment-variables/#argo-server))