### PR TITLE
Fix #160 Minikube tests fail in actions

### DIFF
--- a/scripts/setup-tests.sh
+++ b/scripts/setup-tests.sh
@@ -165,26 +165,14 @@ echo "Waiting for OIDC configuration URL to be available"
 timeout=700
 start_time=$(date +%s)
 while true; do
-    echo curl -k https://$MINIKUBE_HOST/auth/admin/console/
-    curl -k https://$MINIKUBE_HOST/auth/admin/console/
-    echo curl -k https://$MINIKUBE_HOST/auth/realms/$REALM/
-    curl -k https://$MINIKUBE_HOST/auth/realms/$REALM/
     if curl -k --silent --fail https://$MINIKUBE_HOST/auth/realms/$REALM/; then
         echo "OIDC configuration URL is available"
         break
     fi
     current_time=$(date +%s)
     elapsed_time=$((current_time - start_time))
-    echo "Waiting for OIDC configuration URL (${elapsed_time}s / ${timeout}s)"
-    kubectl get po -A
-    kubectl get ing -A
-    kubectl get Keycloak -A
-    kubectl get KeycloakRealmImport -A
     if [ $elapsed_time -ge $timeout ]; then
         echo "OIDC configuration URL is not available"
-        kubectl -n naavre describe keycloaks.k8s.keycloak.org naavre-keycloak
-        kubectl -n naavre describe keycloakrealmimports.k8s.keycloak.org naavre-keycloak-realm-import
-        kubectl -n ingress-nginx logs -l app.kubernetes.io/instance=ingress-nginx -l app.kubernetes.io/component=controller --tail=-1
         exit 1
     fi
     sleep 6


### PR DESCRIPTION
The issue was happening because both ingresses `naavre-redirect-to-paas` and `naavre-keycloak-ingress` tried to create a rule for `/`.

The issue is solved by manually creating the `naavre-keycloak-ingress` rule to apply to `/auth`, instead of letting the keycloak operator create the one that applies to `/`. 