### PR TITLE
Support mounting extra volumes for specific groups

### DIFF
--- a/values/templates/jupyterhub.yaml
+++ b/values/templates/jupyterhub.yaml
@@ -76,15 +76,21 @@ jupyterhub:
                 spawner.environment['OAUTH_REFRESH_TOKEN'] = auth_state.get('refresh_token')
         c.JupyterHub.authenticator_class = GenericEnvOAuthenticator
       custom_kubespawner.py: |
-        # Workaround for jupyterhub/kubespawner#877
-        # Source: https://discourse.jupyter.org/t/creating-1-pvc-per-profile-and-per-user/31755/5
         from kubespawner import KubeSpawner
         class CustomKubeSpawner(KubeSpawner):
             def get_pvc_manifest(self):
+                # Workaround for jupyterhub/kubespawner#877
+                # Source: https://discourse.jupyter.org/t/creating-1-pvc-per-profile-and-per-user/31755/5
                 self.pvc_name = self._expand_user_properties(self.pvc_name_template)
                 self.pod_name = self._expand_user_properties(self.pod_name_template)
                 return super().get_pvc_manifest()
-                return super().get_pod_manifest()
+            async def get_pod_manifest(self):
+                self.volume_mounts = [
+                    {k: v for k, v in volume_mount.items() if k != 'allowedUsers'}
+                    for volume_mount in self.volume_mounts
+                    if self.user.name in volume_mount.get('allowedUsers', [self.user.name])
+                    ]
+                return await super().get_pod_manifest()
         c.JupyterHub.spawner_class = CustomKubeSpawner
       custom_user_redirect.py: |
         from jupyterhub.utils import url_path_join

--- a/values/templates/jupyterhub.yaml
+++ b/values/templates/jupyterhub.yaml
@@ -86,9 +86,15 @@ jupyterhub:
                 return super().get_pvc_manifest()
             async def get_pod_manifest(self):
                 self.volume_mounts = [
-                    {k: v for k, v in volume_mount.items() if k != 'allowedUsers'}
+                    {k: v for k, v in volume_mount.items() if k != 'allowedGroups'}
                     for volume_mount in self.volume_mounts
-                    if self.user.name in volume_mount.get('allowedUsers', [self.user.name])
+                    if (
+                        ('allowedGroups' not in volume_mount)
+                        or (
+                            set([g.name for g in self.user.groups])
+                            & set(volume_mount['allowedGroups'])
+                            )
+                        )
                     ]
                 return await super().get_pod_manifest()
         c.JupyterHub.spawner_class = CustomKubeSpawner

--- a/values/values.yaml
+++ b/values/values.yaml
@@ -58,6 +58,7 @@ global:
         #   mountPath: /path/to/my-mount-point
         #   readOnly: true  # optional
         #   subPath: 'path/in/pv'  # optional
+        #   allowedUsers: ['example_username']  # optional
 
   externalServices:
     argoWorkflows:

--- a/values/values.yaml
+++ b/values/values.yaml
@@ -58,7 +58,7 @@ global:
         #   mountPath: /path/to/my-mount-point
         #   readOnly: true  # optional
         #   subPath: 'path/in/pv'  # optional
-        #   allowedUsers: ['example_username']  # optional
+        #   allowedGroups: ['example_group']  # optional
 
   externalServices:
     argoWorkflows:


### PR DESCRIPTION
Adds support for an additional `allowedGroups` field in `global.common.userPods.extraVolumeMounts`, limiting mounting of a volume to Jupyter Lab pods to members of specific groups. 

The feature requires the change proposed in NaaVRE/NaaVRE-workflow-service#77 to mount these volumes on argo pods. 