### PR TITLE
PoC jupyter kernel in docker with enterprise gateway

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -154,6 +154,10 @@ gen_helm_repo_add() {
   cmd+=" && helm repo add $1 jupyterhub https://jupyterhub.github.io/helm-chart/"
   cmd+=" && helm repo add $1 bitnami https://charts.bitnami.com/bitnami"
   cmd+=" && helm repo add $1 seaweedfs https://seaweedfs.github.io/seaweedfs/helm"
+  # enterprise-gateway does not publish a repo, so we download the chart ourselves
+  eg_chart_version="$(yq '.dependencies[] | select(.name == "enterprise-gateway") | .version' naavre/Chart.yaml)"
+  cmd+=" && curl -L \"https://github.com/jupyter-server/enterprise_gateway/releases/download/v$eg_chart_version/jupyter_enterprise_gateway_helm-$eg_chart_version.tar.gz\" -o /tmp/enterprise-gateway.tar.gz"
+  cmd+=" && tar -xzf /tmp/enterprise-gateway.tar.gz -C /tmp/"
   echo "$cmd"
 }
 

--- a/minikube_tests/charts/argo-workflows-0.33.1-Chart.yaml
+++ b/minikube_tests/charts/argo-workflows-0.33.1-Chart.yaml
@@ -32,6 +32,12 @@ dependencies:
     version: "4.1.0"
     repository: "https://jupyterhub.github.io/helm-chart/"
     condition: jupyterhub.enabled
+  - name: enterprise-gateway
+    version: "3.2.3"
+    # This chart does not publish a repository. We download the chart .tgz with
+    # `./deploy.sh repo-add` instead
+    repository: "file:///tmp/enterprise-gateway"
+    condition: enterprise-gateway.enabled
   - name: "seaweedfs"
     version: "4.0.406"
     repository: "https://seaweedfs.github.io/seaweedfs/helm"

--- a/minikube_tests/charts/argo-workflows-0.45.6-Chart.yaml
+++ b/minikube_tests/charts/argo-workflows-0.45.6-Chart.yaml
@@ -32,6 +32,12 @@ dependencies:
     version: "4.1.0"
     repository: "https://jupyterhub.github.io/helm-chart/"
     condition: jupyterhub.enabled
+  - name: enterprise-gateway
+    version: "3.2.3"
+    # This chart does not publish a repository. We download the chart .tgz with
+    # `./deploy.sh repo-add` instead
+    repository: "file:///tmp/enterprise-gateway"
+    condition: enterprise-gateway.enabled
   - name: "seaweedfs"
     version: "4.0.406"
     repository: "https://seaweedfs.github.io/seaweedfs/helm"

--- a/minikube_tests/setup-tests.sh
+++ b/minikube_tests/setup-tests.sh
@@ -164,6 +164,11 @@ deploy_naavre(){
     cp ./minikube_tests/configuration.json ../
   fi
 
+  # Add the third-party Helm repos
+  if [ "$DEPLOY_NAAAVRE" == "true" ]; then
+    ./deploy.sh repo-add
+  fi
+
   if [ -n "$CHART_FILE" ]; then
     CURRENT_DIR=$(basename "$(pwd)")
     if [ "$CURRENT_DIR" != "NaaVRE-helm" ]; then
@@ -180,10 +185,6 @@ deploy_naavre(){
     cd naavre && helm dependency update && cd ..
   fi
 
-  # Add the third-party Helm repos
-  if [ "$DEPLOY_NAAAVRE" == "true" ]; then
-    ./deploy.sh repo-add
-  fi
   # Read CELL_GITHUB_TOKEN from dev.env if it exists
   if [ -f "../dev.env" ]; then
     source ../dev.env

--- a/naavre/Chart.lock
+++ b/naavre/Chart.lock
@@ -5,6 +5,9 @@ dependencies:
 - name: jupyterhub
   repository: https://jupyterhub.github.io/helm-chart/
   version: 4.1.0
+- name: enterprise-gateway
+  repository: file:///tmp/enterprise-gateway
+  version: 3.2.3
 - name: seaweedfs
   repository: https://seaweedfs.github.io/seaweedfs/helm
   version: 4.17.0
@@ -26,5 +29,5 @@ dependencies:
 - name: naavre-paas-frontend
   repository: oci://ghcr.io/naavre/charts
   version: v0.2.4
-digest: sha256:57a3ade00855bb9b75474c7a952d7318cba5f55777957820d7d964fb0ded6c84
-generated: "2026-04-15T16:51:44.289662316+02:00"
+digest: sha256:8197952a35baf96ec9c5c7b83e396150dd19b3eefa5c4eb35b6c67076d7c4e93
+generated: "2026-04-22T13:10:38.85182979+02:00"

--- a/naavre/Chart.yaml
+++ b/naavre/Chart.yaml
@@ -32,6 +32,12 @@ dependencies:
     version: "4.1.0"
     repository: "https://jupyterhub.github.io/helm-chart/"
     condition: jupyterhub.enabled
+  - name: enterprise-gateway
+    version: "3.2.3"
+    # This chart does not publish a repository. We download the chart .tgz with
+    # `./deploy.sh repo-add` instead
+    repository: "file:///tmp/enterprise-gateway"
+    condition: enterprise-gateway.enabled
   - name: "seaweedfs"
     version: "4.17.0"
     repository: "https://seaweedfs.github.io/seaweedfs/helm"

--- a/naavre/templates/keycloak.yaml
+++ b/naavre/templates/keycloak.yaml
@@ -175,4 +175,5 @@ spec:
           - profile
           - roles
           - web-origins
+          - openid
 {{- end }}

--- a/naavre/values.yaml
+++ b/naavre/values.yaml
@@ -4,6 +4,9 @@ fullnameOverride: ""
 argo-workflows:
   enabled: true
 
+enterprise-gateway:
+  enabled: true
+
 jupyterhub:
   enabled: true
 

--- a/values/templates/enterprise-gateway.yaml
+++ b/values/templates/enterprise-gateway.yaml
@@ -1,0 +1,18 @@
+enterprise-gateway:
+  enabled: {{ .Values.enterpriseGateway.enabled }}
+
+  global:
+    rbac: true
+    serviceAccountName: 'enterprise-gateway-sa'
+
+  service:
+    type: "ClusterIP"
+
+  kernel:
+    shareGatewayNamespace: "true"
+    cullIdleTimeout: 300
+    cullConnected: true
+    allowedKernels:
+      - r_kubernetes
+      - python_kubernetes
+    defaultKernelName: python_kubernetes

--- a/values/templates/jupyterhub.yaml
+++ b/values/templates/jupyterhub.yaml
@@ -228,6 +228,18 @@ jupyterhub:
         {{- .Values.global.common.userPods.extraVolumeMounts | toYaml | nindent 6 }}
       {{- end }}
 
+    networkPolicy:
+      egress:
+        - ports:
+            - port: 8888
+              protocol: TCP
+          to:
+            - podSelector:
+                matchLabels:
+                  app: enterprise-gateway
+                  component: enterprise-gateway
+                  release: "{{ .Release.Name }}"
+
     extraEnv:
       NAAVRE_ALLOWED_DOMAINS: "{{ .Values.global.ingress.domain }}"
       {{- if .Values.global.insecureSkipVerifySSL }}
@@ -265,6 +277,8 @@ jupyterhub:
           {{- end }}
           environment:
             NAAVRE_LOG_QUERIES: "{{ .configuration.log_queries | default false | printf "%t" }}"
+            # FIXME hard-coded service name
+            JUPYTER_GATEWAY_URL: "http://enterprise-gateway.{{ $.Values.global.namespace }}.svc:8888"
           extra_pod_config:
             securityContext:
               fsGroupChangePolicy: OnRootMismatch

--- a/values/values-deploy-minikube-poc-jeg.yaml
+++ b/values/values-deploy-minikube-poc-jeg.yaml
@@ -1,0 +1,80 @@
+global:
+  namespace: naavre
+
+  # WARNING: don't verify SSL certificates (don't use in production!)
+  insecureSkipVerifySSL: true
+
+  ingress:
+    domain: naavre-dev.minikube.test
+    seaweedfsS3Domain: s3.naavre-dev.minikube.test
+    enterpriseGatewayDomain: jeg.naavre-dev.minikube.test # TODO: try to use in-cluster address
+    redirectDomainToPaasFrontend: true
+
+  secrets:
+    k8sSecretCreator:
+      apiToken: fake-k8sSecretCreator-apiToken
+    keycloak:
+      adminPassword: admin
+      naavreClientSecret: fake-keycloak-naavreClientSecret
+      users:
+        - username: user
+          password: user
+      postgresql:
+        password: fake-keycloak-postgresql-password
+    seaweedfs:
+      catalogueBucket:
+        access_key: fake-s3-access-key
+        secret_key: fake-s3-secret-key
+    naavreCatalogueService:
+      secretKey: fake-naavreCatalogueService-secretKey
+      auth:
+        superuser:
+          email: admin@example.org
+          username: admin
+          password: admin
+      postgresql:
+        password: fake-naavreCatalogueService-postgresql-password
+    naavrePaasFrontend:
+      secretKey: fake-naavrePaasFrontend-secretKey
+
+# common:
+#   userPods:
+#     extraVolumeMounts:
+#       - name: naa-vre-public
+#         mountPath: /home/jovyan/Cloud Storage/naa-vre-public
+#         readOnly: true
+#       - name: naa-vre-user-data
+#         mountPath: /home/jovyan/Cloud Storage/naa-vre-user-data/
+#         subPath: '{unescaped_username}'
+
+jupyterhub:
+  vlabLabels:
+    sampleLabel:
+      title: Sample Label
+      color: "#3c8f49"
+
+  vlabs:
+    openlab:
+      enabled: true
+      slug: openlab
+      title: NaaVRE Open Lab
+      labels: [sampleLabel]
+      description: Open experimentation with virtual labs
+      dirname: Open Lab
+      image:
+        # FIXME: use NaaVRE image
+        # name: ghcr.io/naavre/flavors/naavre-fl-vanilla-jupyter
+        # tag: latest
+        name: quay.io/jupyterhub/k8s-singleuser-sample
+        tag: "4.1.0"
+      configuration:
+        base_image_tags_url: https://github.com/NaaVRE/flavors/releases/latest/download/base_image_tags.json
+        module_mapping_url: https://raw.githubusercontent.com/QCDIS/NaaVRE-conf/main/module_mapping.json
+        log_queries: true
+        # WARNING: with the values below, the deployment will work but containerizing cells won't.
+        # If you need to containerize cells, create your own cells repository using the template at
+        # https://github.com/QCDIS/NaaVRE-cells, generate a token following the instruction in
+        # the repo's README.
+        cell_github_url: https://github.com/user/repo
+        cell_github_token: fake-cell-github-token
+        registry_url: ghcr.io/user/repo

--- a/values/values.yaml
+++ b/values/values.yaml
@@ -98,6 +98,9 @@ argoWorkflows:
   ingress:
     basePath: /argowf
 
+enterpriseGateway:
+  enabled: true
+
 jupyterhub:
   enabled: true
   ingress:


### PR DESCRIPTION
Experiment with running Jupyter kernels in separate containers for NaaVRE/NaaVRE#97. 

The core functionality is provided by [Jupyter Enterprise Gateway](https://jupyter-enterprise-gateway.readthedocs.io/en/latest/index.html)

We explore:

- Volume mounts: mounting `/home/jovyan` and `/home/jovyan/Cloud Storage/*` onto the kernel container
- Custom images (intended to replace flavors)
- Authentication: adding OIDC support
- Authorization: limit the number of concurrent kernels a user can run