### PR TITLE
Fix #256 Gitpuller errors prevent users from starting a VL

### DIFF
--- a/values/templates/jupyterhub.yaml
+++ b/values/templates/jupyterhub.yaml
@@ -254,7 +254,19 @@ jupyterhub:
                     echo '{"CondaKernelSpecManager": {"env_filter": "/opt/conda$", "conda_only": true}}' > /home/jovyan/.jupyter/jupyter_config.json
                     {{- if .configuration.git_public }}
                     cd "Virtual Labs/{{ .dirname }}/"
-                    gitpuller {{ .configuration.git_public.repo }} {{ .configuration.git_public.branch }} "Git public"
+                    git_public_repo="{{ .configuration.git_public.repo }}"
+                    git_public_branch="{{ .configuration.git_public.branch }}"
+                    git_public_dir="Git public"
+                    pull_git_public() {
+                      gitpuller "$git_public_repo" "$git_public_branch" "$git_public_dir"
+                    }
+                    backup_local_git_public() {
+                      mv "$git_public_dir" "$git_public_dir (backup $(date "+%Y-%m-%d %H:%M:%S"))"
+                    }
+                    handle_error() {
+                      echo "An unexpected error has occurred while pulling $git_public_repo to '$git_public_dir'. You can try removing or renaming the '$git_public_dir' folder (if it exists), and run the following command:\n\ngitpuller \"$git_public_repo\" \"$git_public_branch\" \"$git_public_dir\"\n" > "$git_public_dir error.txt"
+                    }
+                    pull_git_public || backup_local_git_public && pull_git_public || handle_error
                     {{- end }}
                     {{- if .postStartShSnippet }}
                     {{- .postStartShSnippet | nindent 20 }}


### PR DESCRIPTION
Currently, `gitpuller` failures lead to `FailedPostStartHook`, which prevent the singleuser instance from starting. 

With this PR, we make sure that `gitpuller` failures never prevent the singleuser instance from starting. If `gitpuller` fails:

- Move the `Git public` folder to `Git public (backup <date & time>)` and re-run `gitpuller`. This will typically solve issues where `gitpuller` is able to pull the repo, but cannot reconciliate upstream and local changes. `Git public` will contain a fresh clone, and `Git public (backup <date>)` will contain the user's changes. 
  <img width="454" height="81" alt="Screenshot-2026-06-01-113811" src="https://github.com/user-attachments/assets/004e2947-3845-4b6e-8088-1d9847abbaca" />

- If `gitpuller` still fails, write an error message and continue with VL spawn. This covers all others errors, including the ones where the git server cannot be reached. Users can run the command in the .txt file and get the full logs for debugging. 
  <img width="1080" height="149" alt="Screenshot-2026-06-01-113939" src="https://github.com/user-attachments/assets/0620c409-27ae-48da-b668-560402a4e290" />
