### PR TITLE
Make files managed by gitpuller read-only

### DIFF
--- a/values/templates/jupyterhub.yaml
+++ b/values/templates/jupyterhub.yaml
@@ -258,7 +258,9 @@ jupyterhub:
                     git_public_branch="{{ .configuration.git_public.branch }}"
                     git_public_dir="Git public"
                     pull_git_public() {
+                      find "${git_public_dir}" -type f | xargs -I{} chmod +w {}
                       gitpuller "$git_public_repo" "$git_public_branch" "$git_public_dir"
+                      find "${git_public_dir}" -type f | xargs -I{} chmod -w {}
                     }
                     backup_local_git_public() {
                       mv "$git_public_dir" "$git_public_dir (backup $(date "+%Y-%m-%d %H:%M:%S"))"

--- a/values/templates/jupyterhub.yaml
+++ b/values/templates/jupyterhub.yaml
@@ -257,10 +257,17 @@ jupyterhub:
                     git_public_repo="{{ .configuration.git_public.repo }}"
                     git_public_branch="{{ .configuration.git_public.branch }}"
                     git_public_dir="Git public"
+                    update_git_files_mode() {
+                      mode=$@
+                      if [ -d "${git_public_dir}" ]; then
+                        git -C "${git_public_dir}" ls-tree -r --name-only HEAD \
+                          | xargs -I{} chmod $mode "${git_public_dir}/{}"
+                      fi
+                    }
                     pull_git_public() {
-                      find "${git_public_dir}" -type f | xargs -I{} chmod +w {}
+                      update_git_files_mode +w
                       gitpuller "$git_public_repo" "$git_public_branch" "$git_public_dir"
-                      find "${git_public_dir}" -type f | xargs -I{} chmod -w {}
+                      update_git_files_mode -w
                     }
                     backup_local_git_public() {
                       mv "$git_public_dir" "$git_public_dir (backup $(date "+%Y-%m-%d %H:%M:%S"))"


### PR DESCRIPTION
After running `gitpuller`, we make the files tracked by git read-only. Jupyter graciously handles this:

<img width="1149" height="544" alt="image" src="https://github.com/user-attachments/assets/fe2759f5-ce27-4f22-8f5d-8ccb3daa714c" />

Users can modify and run notebooks or workflows, but they can't save them. They can 'save as' if they wish to keep their changes. 

Note: we don't make the full `Git public` folder read-only, so users can still create documents there. Making the folder read-only is possible, but will lead to not-so-nice error messages:

<img width="485" height="176" alt="image" src="https://github.com/user-attachments/assets/1ba03fea-a78b-45de-8d6d-f41ec598ba08" />
