### PR TITLE
Bump naavre-paas-frontend to v0.2.6

### DIFF
--- a/naavre/Chart.lock
+++ b/naavre/Chart.lock
@@ -25,6 +25,6 @@ dependencies:
   version: v0.4.0
 - name: naavre-paas-frontend
   repository: oci://ghcr.io/naavre/charts
-  version: v0.2.5
-digest: sha256:dc693140c6cb04a35940d9c1176c5380f7b2bb8804f0a91f5a57bf88559b5b42
-generated: "2026-06-15T15:01:14.348878474+02:00"
+  version: v0.2.6
+digest: sha256:e39035bb25130e8c1cf70803c770a4d3d17b48b0d94182740158c6452061f16e
+generated: "2026-07-01T13:12:25.575759997+02:00"

--- a/naavre/Chart.yaml
+++ b/naavre/Chart.yaml
@@ -58,6 +58,6 @@ dependencies:
     repository: "oci://ghcr.io/naavre/charts"
     condition: naavre-workflow-service.enabled
   - name: "naavre-paas-frontend"
-    version: "v0.2.5"
+    version: "v0.2.6"
     repository: "oci://ghcr.io/naavre/charts"
     condition: naavre-paas-frontend.enabled


### PR DESCRIPTION
https://github.com/NaaVRE/NaaVRE-PaaS-frontend/releases/tag/v0.2.6